### PR TITLE
Time format used for save seems no longer supported. 

### DIFF
--- a/TrafficViewerSDK/Constants.cs
+++ b/TrafficViewerSDK/Constants.cs
@@ -43,7 +43,7 @@ namespace TrafficViewerSDK
 		/// <summary>
 		/// Time format used to save timestamp data
 		/// </summary>
-        public const string COMMON_TIME_FORMAT = "MM/dd/yyyy HH:mm:ss.fff";
+        public const string COMMON_TIME_FORMAT = "MM-dd-yyyy HH:mm:ss.fff";
 		/// <summary>
 		/// String used to mark dynamic elements during request normalization
 		/// </summary>


### PR DESCRIPTION
There are exceptions on file load unable to parse the old file format and defaulting to data separated by -. Updating the time format to use - fixes this issue and also fixes a unit test that was previously failing.