### PR TITLE
Allow configuring test verbosity, except for multi-steps

### DIFF
--- a/CommonControls/OptionsGrid.cs
+++ b/CommonControls/OptionsGrid.cs
@@ -295,8 +295,12 @@ namespace CommonControls
 				r = this._dataGridView.Rows[i];
 				for (j = 0; j < r.Cells.Count; j++)
 				{
-					s += (string)r.Cells[j].Value.ToString();
-					if (j < r.Cells.Count - 1) s += "\t";
+                    var cellValue = r.Cells[j].Value;
+                    if (cellValue != null)
+                    {
+                        s += (string)cellValue;
+                        if (j < r.Cells.Count - 1) s += "\t";
+                    }
 				}
 				values.Add(s);
 			}

--- a/CustomTestsUI/TestOptions.Designer.cs
+++ b/CustomTestsUI/TestOptions.Designer.cs
@@ -42,6 +42,7 @@
             this._textPatternRequestExclusion = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this._checkGenerateAllEncodings = new System.Windows.Forms.CheckBox();
+            this._checkVerbose = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // _checkLoginBeforeEachTest
@@ -57,7 +58,7 @@
             // _checkTestOnlyParameters
             // 
             this._checkTestOnlyParameters.AutoSize = true;
-            this._checkTestOnlyParameters.Location = new System.Drawing.Point(26, 112);
+            this._checkTestOnlyParameters.Location = new System.Drawing.Point(26, 86);
             this._checkTestOnlyParameters.Name = "_checkTestOnlyParameters";
             this._checkTestOnlyParameters.Size = new System.Drawing.Size(173, 17);
             this._checkTestOnlyParameters.TabIndex = 1;
@@ -155,18 +156,30 @@
             // _checkGenerateAllEncodings
             // 
             this._checkGenerateAllEncodings.AutoSize = true;
-            this._checkGenerateAllEncodings.Location = new System.Drawing.Point(26, 71);
+            this._checkGenerateAllEncodings.Location = new System.Drawing.Point(26, 57);
             this._checkGenerateAllEncodings.Name = "_checkGenerateAllEncodings";
             this._checkGenerateAllEncodings.Size = new System.Drawing.Size(137, 17);
             this._checkGenerateAllEncodings.TabIndex = 16;
             this._checkGenerateAllEncodings.Text = "Generate All Encodings";
             this._checkGenerateAllEncodings.UseVisualStyleBackColor = true;
+            this._checkGenerateAllEncodings.CheckedChanged += new System.EventHandler(this._checkGenerateAllEncodings_CheckedChanged);
+            // 
+            // _checkVerbose
+            // 
+            this._checkVerbose.AutoSize = true;
+            this._checkVerbose.Location = new System.Drawing.Point(26, 117);
+            this._checkVerbose.Name = "_checkVerbose";
+            this._checkVerbose.Size = new System.Drawing.Size(65, 17);
+            this._checkVerbose.TabIndex = 17;
+            this._checkVerbose.Text = "Verbose";
+            this._checkVerbose.UseVisualStyleBackColor = true;
             // 
             // TestOptions
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(321, 415);
+            this.Controls.Add(this._checkVerbose);
             this.Controls.Add(this._checkGenerateAllEncodings);
             this.Controls.Add(this._textPatternRequestExclusion);
             this.Controls.Add(this.label3);
@@ -207,5 +220,6 @@
         private System.Windows.Forms.TextBox _textPatternRequestExclusion;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.CheckBox _checkGenerateAllEncodings;
+        private System.Windows.Forms.CheckBox _checkVerbose;
     }
 }

--- a/CustomTestsUI/TestOptions.cs
+++ b/CustomTestsUI/TestOptions.cs
@@ -26,6 +26,7 @@ namespace CustomTestsUI
         {
             _checkLoginBeforeEachTest.Checked = _testFile.LoginBeforeTests;
             _checkTestOnlyParameters.Checked = _testFile.TestOnlyParameters;
+            _checkVerbose.Checked = _testFile.Verbose;
             _textNumThreads.Text = _testFile.NumberOfThreads.ToString();
             _checkGenerateAllEncodings.Checked = _testFile.GenerateAllEncodings;
             _textPatternOfFirstTestRequest.Text = _testFile.PatternOfFirstRequestToTest;
@@ -43,6 +44,7 @@ namespace CustomTestsUI
         {
             _testFile.LoginBeforeTests = _checkLoginBeforeEachTest.Checked;
             _testFile.TestOnlyParameters = _checkTestOnlyParameters.Checked;
+            _testFile.Verbose = _checkVerbose.Checked;
             int numThreads;
             if (int.TryParse(_textNumThreads.Text, out numThreads)) 
             {
@@ -56,7 +58,9 @@ namespace CustomTestsUI
             this.Hide();
         }
 
+        private void _checkGenerateAllEncodings_CheckedChanged(object sender, EventArgs e)
+        {
 
-
+        }
     }
 }

--- a/Testing/CustomTestsFile.cs
+++ b/Testing/CustomTestsFile.cs
@@ -172,6 +172,24 @@ namespace Testing
         }
 
 
+        /// <summary>
+        /// Whether the testing is verbose (less performance)
+        /// </summary>
+        public bool Verbose
+        {
+            get
+            {
+                object value = GetOption("Verbose");
+                if (value == null) return false;
+                return Convert.ToBoolean(value);
+            }
+            set
+            {
+                SetSingleValueOption("Verbose",value);
+            }
+        }
+
+
 
         /// <summary>
         /// If should login before tests

--- a/TrafficViewerControls/DefaultExploiters/CustomTestsExploiter.cs
+++ b/TrafficViewerControls/DefaultExploiters/CustomTestsExploiter.cs
@@ -37,6 +37,7 @@ namespace TrafficViewerControls.DefaultExploiters
         private CustomTestsFile _testFile;
         private Queue<string> _multiStepsToTest;
         private DefaultNetworkSettings _netSettings;
+        private bool _verbose = false;
 
         public string Caption
         {
@@ -81,7 +82,10 @@ namespace TrafficViewerControls.DefaultExploiters
         /// <param name="args"></param>
         public void Log(string format, params object[] args)
         {
-            HttpServerConsole.Instance.WriteLine(LogMessageType.Error, format, args);
+            if (_verbose)
+            {
+                HttpServerConsole.Instance.WriteLine(LogMessageType.Error, format, args);
+            }
         }
 
 
@@ -98,7 +102,13 @@ namespace TrafficViewerControls.DefaultExploiters
 
             HttpResponseInfo resp = null;
 
-            var tvReqInfo = SaveRequest("Custom Test", reqInfo, useSSL, String.Empty, reqTime, reqTime, "");
+
+            TVRequestInfo tvReqInfo = null;
+
+            if (_verbose)
+            {
+                tvReqInfo = SaveRequest("Custom Test", reqInfo, useSSL, String.Empty, reqTime, reqTime, "");
+            }
 
             try
             {
@@ -113,9 +123,12 @@ namespace TrafficViewerControls.DefaultExploiters
             {
                 PatternTracker.Instance.UpdatePatternValues(resp);
                 response = resp.ToString();
-                tvReqInfo.ResponseTime = DateTime.Now;
-                _trafficFile.UpdateRequestInfo(tvReqInfo);
-                _trafficFile.SaveResponse(tvReqInfo.Id,resp.ToArray());
+                if (tvReqInfo != null)
+                {
+                    tvReqInfo.ResponseTime = DateTime.Now;
+                    _trafficFile.UpdateRequestInfo(tvReqInfo);
+                    _trafficFile.SaveResponse(tvReqInfo.Id, resp.ToArray());
+                }
             }
             else
             {
@@ -186,6 +199,20 @@ namespace TrafficViewerControls.DefaultExploiters
         public void Run()
         {
             _runnable = true;
+
+
+            TestSelectedRequests();
+
+            TestMultiSteps();
+
+            
+            _trafficFile.SetState(AccessorState.Idle);
+            _runnable = false;
+        }
+
+
+        private void TestSelectedRequests()
+        {
             var customTests = _testFile.GetCustomTests().Values;
             Tester tester = new Tester(this, _testFile);
             if (_requestsToTest.Count == 0)
@@ -217,10 +244,10 @@ namespace TrafficViewerControls.DefaultExploiters
                     workingReqInfo = new HttpRequestInfo(reqBytes, true);
                     workingReqInfo.IsSecure = workingEntry.IsHttps;
                 }
-                
-           
+
+
                 string rawRequest = workingReqInfo.ToString();
-                string rawResponse = respBytes!=null ? Constants.DefaultEncoding.GetString(respBytes) : String.Empty;
+                string rawResponse = respBytes != null ? Constants.DefaultEncoding.GetString(respBytes) : String.Empty;
                 if (ShouldBeTested(rawRequest, _testFile.GetAttackTargetList()))
                 {
 
@@ -269,17 +296,25 @@ namespace TrafficViewerControls.DefaultExploiters
                                 }
                             }
                         }
-                        testExecution.StartTestsAsync();
-                        while (testExecution.IsRunning)
-                        {
-                            if (!_runnable)
-                            {
-                                testExecution.CancelTests();
-                            }
-                            //wait for the test execution to complete
-                            Thread.Sleep(10);
-                        }
                     }
+
+                    testExecution.StartTestsAsync();
+
+                    while (testExecution.IsRunning)
+                    {
+                        if (!_runnable)
+                        {
+                            testExecution.CancelTests();
+                        }
+                        //wait for the test execution to complete
+                        HttpServerConsole.Instance.WriteLine(LogMessageType.Notification,
+                                  "Requests in queue: {0}, Tests in queue for current request: {1}.",
+                                  _requestsToTest.Count, testExecution.TestsQueue.Count);
+                        Thread.Sleep(10);
+                    }
+
+                    HttpServerConsole.Instance.WriteLine(LogMessageType.Notification,
+                                     "Test execution completed.");
 
                 }
                 if (_requestsToTest.Count > 0)
@@ -287,8 +322,10 @@ namespace TrafficViewerControls.DefaultExploiters
                     _requestsToTest.Dequeue();
                 }
             }
+        }
 
-
+        private void TestMultiSteps()
+        {
             //we also initialize all multi-step operations
             List<string> multiStepList = _testFile.GetMultiStepList();
 
@@ -303,7 +340,8 @@ namespace TrafficViewerControls.DefaultExploiters
                 }
                 else
                 {
-                    SdkSettings.Instance.Logger.Log(TraceLevel.Error, "Multi-Step path '{0}' does not exist.", path);
+                    HttpServerConsole.Instance.WriteLine(LogMessageType.Error,
+                                      "Multi-Step path '{0}' does not exist.", path);
                 }
             }
 
@@ -317,7 +355,7 @@ namespace TrafficViewerControls.DefaultExploiters
                 TrafficViewerFile htd = new TrafficViewerFile();
                 if (isAbl)
                 {
-                    SdkSettings.Instance.Logger.Log(TraceLevel.Error, "ABL files are not supported");
+                    HttpServerConsole.Instance.WriteLine(LogMessageType.Error, "ABL files are not supported");
                     continue;
                 }
                 else
@@ -325,8 +363,6 @@ namespace TrafficViewerControls.DefaultExploiters
                     htd.Open(path);
                 }
 
-                
-                
                 SequentialAttackProxy proxy = GetTestProxy(_netSettings, true) as SequentialAttackProxy;
                 proxy.Start();
 
@@ -337,7 +373,7 @@ namespace TrafficViewerControls.DefaultExploiters
 
                 do
                 {
-                   reqSender.Send(htd);
+                    reqSender.Send(htd);
                 }
                 while (!proxy.TestComplete && _runnable);
 
@@ -348,9 +384,8 @@ namespace TrafficViewerControls.DefaultExploiters
                     _multiStepsToTest.Dequeue();
                 }
             }
-            _trafficFile.SetState(AccessorState.Idle);
-            _runnable = false;
         }
+
 
         private bool ShouldBeTested(string rawRequest, Dictionary<string, AttackTarget> attackTargetLists)
         {
@@ -374,6 +409,7 @@ namespace TrafficViewerControls.DefaultExploiters
         public void SetTestFile(CustomTestsFile testFile)
         {
             _testFile = testFile;
+            _verbose = testFile.Verbose;
         }
 
         public BaseAttackProxy GetTestProxy(INetworkSettings networkSettings, bool isSequential)

--- a/TrafficViewerControls/TextBoxes/RtfBuilder.cs
+++ b/TrafficViewerControls/TextBoxes/RtfBuilder.cs
@@ -286,7 +286,7 @@ namespace TrafficViewerControls.TextBoxes
 	/// </summary>
 	public class RtfHighlight
 	{
-		private Color DEFAULT_DIFF_COL = Color.Red;
+		private Color DEFAULT_DIFF_COL = Color.DarkMagenta;
 
 		private int _start = -1;
 		/// <summary>

--- a/TrafficViewerInstance/TrafficViewerConstants.cs
+++ b/TrafficViewerInstance/TrafficViewerConstants.cs
@@ -14,7 +14,7 @@ namespace TrafficViewerInstance
     /// </summary>B
     public static class TrafficViewerConstants
     {
-        public const string BUILD = "302";
+        public const string BUILD = "303";
         
         public const string DLL_VERSION = "2.2.0."+BUILD;
 

--- a/TrafficViewerInstance/TrafficViewerOptions.cs
+++ b/TrafficViewerInstance/TrafficViewerOptions.cs
@@ -296,7 +296,7 @@ namespace TrafficViewerInstance
 			get
 			{
 				object value = GetOption("ColorDiffText");
-				if (value == null) return "Red";
+				if (value == null) return "DarkMagenta";
 				return (string)value;
 			}
 			set
@@ -313,7 +313,7 @@ namespace TrafficViewerInstance
 			get
 			{
 				object value = GetOption("ColorHighlight");
-				if (value == null) return "Red";
+				if (value == null) return "DarkMagenta";
 				return (string)value;
 			}
 			set

--- a/TrafficViewerSDK/Http/HttpClientConnection.cs
+++ b/TrafficViewerSDK/Http/HttpClientConnection.cs
@@ -114,7 +114,7 @@ namespace TrafficViewerSDK.Http
 		public void SecureStream(string host)
 		{
 			SslStream secureStream = new SslStream(_stream, false, new RemoteCertificateValidationCallback(ValidateServerCertificate), null);
-			secureStream.AuthenticateAsClient(host, null, System.Security.Authentication.SslProtocols.Default, false);
+			secureStream.AuthenticateAsClient(host, null, System.Security.Authentication.SslProtocols.Tls12, false);
 			_stream = secureStream;
 		}
 

--- a/TrafficViewerSDK/Options/ParsingOptions.cs
+++ b/TrafficViewerSDK/Options/ParsingOptions.cs
@@ -473,7 +473,7 @@ namespace TrafficViewerSDK.Options
                 result.Add("description=[^=]*automatic\\s?explore.*\\s", "Crimson");
                 result.Add("description=[^=]*cached.*\\s", "DarkGreen");
                 result.Add("description=[^=]*to\\s?proxy.*\\s", "DarkPurple");
-                result.Add("description=[^=]*vulnerability.*\\s", "Red");
+                result.Add("description=[^=]*vulnerability.*\\s", "DarkMagenta");
                 result.Add("scheme=\\bhttp\\s", "DarkSlateGray"); 
 
 			}

--- a/TrafficViewerUnitTest/UtilsUnitTest.cs
+++ b/TrafficViewerUnitTest/UtilsUnitTest.cs
@@ -156,7 +156,7 @@ namespace TrafficViewerUnitTest
         public void Base64DecodeDot()
         {
             string control = "The quick brown fox jumps over the lazy rabbit";
-            Assert.AreEqual(control, Utils.Base64Decode("VGhlIHF1aWNrIGJyb3duIGZveA.anVtcHMgb3ZlciB0aGUgbGF6eSByYWJiaXQ"));
+            Assert.AreEqual(control, Utils.Base64Decode("VGhlIHF1aWNrIGJyb3duIGZveCA.anVtcHMgb3ZlciB0aGUgbGF6eSByYWJiaXQ"));
         }
 
         [TestMethod]


### PR DESCRIPTION
Updating the UI during test decreases performance. A new options accessible from Exploit > Custom Tests >Configure > Options allows user to configure whether negative tests and other messages will be displayed in the UI during tests.